### PR TITLE
feat(organization): add organization schema and API routes

### DIFF
--- a/Desktop/Flood App/backend/models/Request.js
+++ b/Desktop/Flood App/backend/models/Request.js
@@ -10,7 +10,12 @@ const RequestSchema = new mongoose.Schema({
   },
   num_people: Number,
   additional_notes: String,
-  status: { type: String, enum: ["pending", "in_progress", "completed"], default: "pending" },
+  status: { 
+    type: String, 
+    enum: ["pending", "booked", "assigned", "in_progress", "completed"],
+    default: "pending" 
+  },
+  organization_id: { type: mongoose.Schema.Types.ObjectId, ref: "Organization", default: null },
   created_at: { type: Date, default: Date.now },
   updated_at: { type: Date, default: Date.now }
 });

--- a/Desktop/Flood App/backend/models/Team.js
+++ b/Desktop/Flood App/backend/models/Team.js
@@ -1,0 +1,11 @@
+const mongoose = require("mongoose");
+
+const TeamSchema = new mongoose.Schema({
+  organization_id: { type: String, required: true },
+  volunteers: [{ type: String }], // เก็บ ID ของอาสาสมัคร
+  max_capacity: { type: Number, default: 5 }, // จำนวนสูงสุดของอาสาสมัครในทีม
+  status: { type: String, enum: ["available", "assigned"], default: "available" },
+  current_request: { type: String, default: null } // คำขอที่ทีมนี้กำลังทำ
+});
+
+module.exports = mongoose.model("Team", TeamSchema);

--- a/Desktop/Flood App/backend/models/Tracking.js
+++ b/Desktop/Flood App/backend/models/Tracking.js
@@ -14,4 +14,4 @@ const TrackingSchema = new mongoose.Schema({
   ]
 });
 
-module.exports = mongoose.model("Tracking", TrackingSchema);
+module.exports = mongoose.model("trackings", TrackingSchema);

--- a/Desktop/Flood App/backend/routes/organizations.js
+++ b/Desktop/Flood App/backend/routes/organizations.js
@@ -1,0 +1,20 @@
+const express = require("express");
+const mongoose = require("mongoose");
+const Request = require("../models/Request");
+const router = express.Router();
+
+// 📌 GET /organizations/:organization_id/requests → ดึงคำขอช่วยเหลือขององค์กร
+router.get("/:organization_id/requests", async (req, res) => {
+  try {
+      if (!mongoose.Types.ObjectId.isValid(req.params.organization_id)) {
+          return res.status(400).json({ message: "Invalid organization_id format" });
+      }
+
+      const requests = await Request.find({ organization_id: req.params.organization_id });
+      res.json(requests);
+  } catch (error) {
+      res.status(500).json({ error: error.message });
+  }
+});
+
+module.exports = router;

--- a/Desktop/Flood App/backend/routes/teams.js
+++ b/Desktop/Flood App/backend/routes/teams.js
@@ -1,0 +1,86 @@
+const express = require("express");
+const mongoose = require("mongoose");
+const Team = require("../models/Team");
+const Request = require("../models/Request");
+
+const router = express.Router();
+
+// ฟังก์ชันตรวจสอบว่า ID เป็น ObjectId หรือไม่
+const isValidObjectId = (id) => mongoose.Types.ObjectId.isValid(id);
+
+// 📌 API สร้างทีมใหม่
+router.post("/create", async (req, res) => {
+  try {
+    const { organization_id, volunteers, max_capacity } = req.body;
+
+    const newTeam = new Team({
+      organization_id,
+      volunteers,
+      max_capacity
+    });
+
+    await newTeam.save();
+    res.status(201).json({ message: "Team created successfully", team: newTeam });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// 📌 API ดึงข้อมูลทีมขององค์กร
+router.get("/:organization_id", async (req, res) => {
+  try {
+    const teams = await Team.find({ organization_id: req.params.organization_id });
+    res.json(teams);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// 📌 Assign Team to Request
+router.post("/assign", async (req, res) => {
+    try {
+        const { organization_id, request_id, team_id } = req.body;
+
+         // ตรวจสอบ request_id ก่อน ว่าเป็น ObjectId หรือไม่
+         if (!isValidObjectId(request_id)) {
+            return res.status(400).json({ message: "Invalid request_id format" });
+        }
+
+        // ดึง Request ถ้าไม่เจอให้แจ้งว่า "Request not found"
+        const request = await Request.findById(request_id);
+        if (!request) {
+            return res.status(404).json({ message: "Request not found" });
+        }
+
+        // ตรวจสอบว่าคำขอนี้ถูก Assigned ไปแล้วหรือยัง
+        if (request.assigned_team) {
+            return res.status(400).json({ message: "This request has already been assigned to a team." });
+        }
+
+        //  หา Team ที่ต้องการ
+        const team = await Team.findById(team_id);
+        if (!team) {
+            return res.status(400).json({ message: "Team not found" });
+        }
+
+        //  ตรวจสอบว่า Team นี้เป็นของ Organization ที่ส่งมา
+        if (team.organization_id.toString() !== organization_id) {
+            return res.status(400).json({ message: "This team does not belong to the specified organization." });
+        }
+
+        // อัปเดต team และ request
+        team.current_request = request_id;
+        request.status = "assigned";
+        request.assigned_team = team_id;
+
+        await team.save();
+        await request.save();
+
+        res.json({ message: "Team assigned successfully", status: "assigned" });
+    } catch (error) {
+        res.status(500).json({ error: error.message });
+    }
+});
+
+
+module.exports = router;

--- a/Desktop/Flood App/backend/routes/tracking.js
+++ b/Desktop/Flood App/backend/routes/tracking.js
@@ -29,6 +29,7 @@ router.post("/", async (req, res) => {
 // 📌 1️⃣ API ให้ Victim ดูสถานะของคำขอ
 router.get("/:request_id", async (req, res) => {
   try {
+    console.log("🔎 Request ID:", req.params.request_id);  // เช็กว่ามันได้ค่าอะไรมา
     const tracking = await Tracking.findOne({ request_id: req.params.request_id });
     if (!tracking) return res.status(404).json({ message: "ไม่พบข้อมูลติดตามสถานะ" });
     res.json(tracking);

--- a/Desktop/Flood App/backend/server.js
+++ b/Desktop/Flood App/backend/server.js
@@ -2,35 +2,49 @@ require("dotenv").config(); // โหลดค่าจาก .env
 const express = require("express");
 const mongoose = require("mongoose");
 const cors = require("cors");
+
+// Import Routes
 const trackingRoutes = require("./routes/tracking");
 const victimRoutes = require("./routes/victims");
 const requestsRoutes = require("./routes/requests");
+const teamRoutes = require("./routes/teams");
+const organizationRoutes = require("./routes/organizations");
 
 const app = express();
 app.use(express.json());
 app.use(cors());
+
 app.use("/api/victims", victimRoutes);
 app.use("/api/requests", requestsRoutes);
 app.use("/api/tracking", trackingRoutes);
+app.use("/api/teams", teamRoutes);
+app.use("/api/organizations", require("./routes/organizations"));
+
 
 const PORT = process.env.PORT || 5000;
 const MONGO_URI = process.env.MONGO_URI;  
 
-mongoose
-  .connect(MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true })
-  .then(() => console.log("✅ MongoDB connected!"))
-  .catch((err) => console.error("❌ MongoDB connection error:", err));
+const startServer = async () => {
+  try {
+    await mongoose.connect(MONGO_URI, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true
+    });
+    console.log(" MongoDB connected!");
 
-app.get("/", (req, res) => {
-  res.json({ message: "Flood Relief API is running..." });
-});
+    // Show all available routes
+    console.log("\n Available Routes:");
+    app._router.stack
+      .filter((r) => r.route)
+      .forEach((r) => console.log(`👉 [${Object.keys(r.route.methods).join(', ').toUpperCase()}] /api${r.route.path}`));
+    console.log("\n");
 
-console.log("✅ Available Routes:");
-app._router.stack.forEach((r) => {
-  if (r.route && r.route.path) {
-    console.log(`👉 [${Object.keys(r.route.methods).join(', ').toUpperCase()}] ${r.route.path}`);
+    app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
+  } catch (error) {
+    console.error("❌ MongoDB connection error:", error);
+    process.exit(1);
   }
-});
+};
 
-
-app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
+// Start Server
+startServer();


### PR DESCRIPTION
รายละเอียดของ PR นี้
- เพิ่ม Schema ของ `organization` ใน MongoDB
- สร้าง API สำหรับจัดการองค์กร (Organizations)
- เพิ่ม API ให้ `organization` สามารถจองและยกเลิกคำขอช่วยเหลือได้
- เพิ่ม API สำหรับดึงคำขอช่วยเหลือที่เกี่ยวข้องกับองค์กร

ทำอะไร
- สร้าง `organization` model ใหม่
- เพิ่ม API `GET /api/organizations/:id/requests` สำหรับดึงคำขอขององค์กร
- เพิ่ม `POST /api/requests/:id/book` ให้ `organization` สามารถจองคำขอได้
- เพิ่ม `POST /api/requests/:id/cancel-booking` ให้ `organization` ยกเลิกการจองได้